### PR TITLE
Improve documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,11 +2,15 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    python: "3.13"
+    python: "3.14"
   jobs:
-    post_create_environment:
-      - python -m pip install poetry
-    post_install:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
+    pre_create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_environment:
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --group docs
 sphinx:
-   configuration: docs/source/conf.py
+  configuration: docs/source/conf.py

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,16 @@ include Config.mk
 
 .EXPORT_ALL_VARIABLES:
 
+.PHONY: help python-help
+
 help:
-	@echo "Recipes for ${PACKAGE_NAME} package"
-	@echo
-	@echo "General options"
+	@echo "Targets for ${PACKAGE_NAME} package"
 	@echo "-----------------------------------------------------------------------"
-	@echo "help:                    This help"
+	@printf "%-22s %s\n" "help" "Show this help"
 	@echo
 	@make --quiet python-help
 	@echo
+	@make --quiet version-help
 	@echo
 	@make --quiet HELP_PREFIX="docs." docs.help
 

--- a/Python.mk
+++ b/Python.mk
@@ -21,22 +21,20 @@ BUILDER_RUN?=${BUILDER_EXECUTABLE} run
 
 # Recipes ************************************************************************************
 .PHONY: python-help requirements beautify lint tests clean pull-request publish  \
-		flake sort-imports
+		flake8 
 
 python-help:
-	@echo "Python options"
+	@echo "Python targets"
 	@echo "-----------------------------------------------------------------------"
-	@echo "python-help:             This help"
-	@echo "requirements:            Install package requirements"
-	@echo "black:                   Reformat code using Black"
-	@echo "beautify-imports:        Reformat and sort imports"
-	@echo "beautify:                Reformat code (beautify-imports + black)"
-	@echo "lint:                    Check code format"
-	@echo "tests:                   Run tests with coverage"
-	@echo "clean:                   Clean compiled files"
-	@echo "pull-request:            Helper to run when a pull request is made"
-	@echo "sort-imports:            Sort imports"
-	@echo "build-doc-html:          Build documentation HTML files"
+	@printf "%-22s %s\n" "python-help" "Show this help"
+	@printf "%-22s %s\n" "requirements" "Install package requirements"
+	@printf "%-22s %s\n" "beautify" "Reformat code (ruff fix + format)"
+	@printf "%-22s %s\n" "lint" "Run ruff lint checks"
+	@printf "%-22s %s\n" "tests" "Run tests with coverage"
+	@printf "%-22s %s\n" "clean" "Remove build, cache, coverage artifacts"
+	@printf "%-22s %s\n" "pull-request" "Run lint and tests"
+	@printf "%-22s %s\n" "build" "Build the package"
+	@printf "%-22s %s\n" "publish" "Publish to configured PyPI repo"
 
 # Code recipes
 requirements:

--- a/README.rst
+++ b/README.rst
@@ -20,15 +20,15 @@
 
 .. start-doc
 
-======================================
-View for Pydantic models documentation
-======================================
+===============================
+Typed views for Pydantic models
+===============================
 
-This package provides a simple way to create `views` from `pydantic <https://docs.pydantic.dev/latest/>`_ models. A view is
-another `pydantic <https://docs.pydantic.dev/latest/>`_ models with some of field of original model. So, for example, 
-read only fields does not appears on `Create` or `Update` views.
+pydantic-views lets you derive focused, type-safe Pydantic models ("views") from a base model.
+Each view exposes only the fields appropriate for a given operation—create, update, load, or a custom flow—so you avoid
+hand-maintaining parallel schemas.
 
-As rest service definition you could do:
+Typical service signatures become easy to express:
 
 .. code-block:: python
 
@@ -46,13 +46,12 @@ As rest service definition you could do:
 Features
 --------
 
-- Unlimited views per model.
-- Create view for referenced inner models.
-- It is possible to set a view manually.
-- Tested code.
-- Full typed.
-- Opensource.
-  
+- Unlimited views per model (create, update, load, custom).
+- Works on nested models; referenced models get views too.
+- Builders for common patterns, or define views manually.
+- Fully typed with shipped ``py.typed`` and tests.
+- Open source and published on PyPI.
+
 
 ------------
 Installation
@@ -70,44 +69,50 @@ Using `poetry <https://python-poetry.org/>`_:
 
    poetry add pydantic-views
 
+Using `uv <https://docs.astral.sh/uv/>`_:
+
+.. code-block:: bash
+
+   uv add pydantic-views
+
 
 ----------
-How to use
+Quickstart
 ----------
 
-When you define a pydantic model you must mark the access model for each field. It means
-you should use our `annotations <https://pydantic-views.readthedocs.io/latest/api.html#field-annotations>`_ to define field typing.
+Mark each field with its access mode using the provided `annotations <https://pydantic-views.readthedocs.io/latest/api.html#field-annotations>`_.
+Unmarked fields default to read/write.
 
 .. code-block:: python
 
    from typing import Annotated
-   from pydantic import BaseModel, gt
-   from pydantic_views import ReadOnly, ReadOnlyOnCreation, Hidden, AccessMode
+
+   from pydantic import BaseModel, computed_field, gt
+   from pydantic_views import AccessMode, Hidden, ReadOnly, ReadOnlyOnCreation
 
    class ExampleModel(BaseModel):
-
-       # No marked fields are treated like ReadAndWrite fields.
+       # Unmarked fields are read/write everywhere.
        field_str: str
 
-       # Read only fields are removed on view for create and update views.
+       # Read-only fields are removed from create and update views.
        field_read_only_str: ReadOnly[str]
 
-       # Read only on creation fields are removed on view for create, update and load views. 
-       # But it is shown on create result view.
+       # Read-only-on-creation fields are hidden on create, update and load views,
+       # but appear on create-result views.
        field_api_secret: ReadOnlyOnCreation[str]
 
-       # It is possible to set more than one access mode and to use annotation standard pattern.
+       # Combine access modes with Annotated and keep validators (gt in this case).
        field_int: Annotated[int, AccessMode.READ_ONLY, AccessMode.WRITE_ONLY_ON_CREATION, gt(5)]
 
-       # Hidden field do not appears in any view.
+       # Hidden fields never appear.
        field_hidden_int: Hidden[int]
 
-       # Computed fields only appears on reading views.
+       # Computed fields appear only on read views.
        @computed_field
        def field_computed_field(self) -> int:
            return self.field_hidden_int * 5
 
-So, in order to build a `Load` view it is so simple:
+Build a load view:
 
 .. code-block:: python
 
@@ -115,7 +120,7 @@ So, in order to build a `Load` view it is so simple:
 
    ExampleModelLoad = BuilderLoad().build_view(ExampleModel)
 
-It is equivalent to:
+Which is equivalent to:
 
 
 .. code-block:: python
@@ -128,7 +133,7 @@ It is equivalent to:
        field_int: Annotated[int, gt(5)]
        field_computed_field: int
 
-In same way to build a `Update` view you must do:
+To build an update view:
 
 .. code-block:: python
 
@@ -136,19 +141,18 @@ In same way to build a `Update` view you must do:
 
    ExampleModelUpdate = BuilderUpdate().build_view(ExampleModel)
    
-It is equivalent to:
+Which is equivalent to:
 
 .. code-block:: python
 
-   from pydantic import PydanticUndefined
+   from pydantic import Field, PydanticUndefined
    from pydantic_views import View
 
    class ExampleModelUpdate(View[ExampleModel]):
        field_str: str = Field(default_factory=lambda: PydanticUndefined)
 
-As you can see, on `Update` view all fields has a default factory returning `PydanticUndefined`
-in order to make them optionals. And when an update view is applied to a given model, the fields that are 
-not set (use default value) will not be applied to the model.
+On ``Update`` views every field uses a default factory that returns ``PydanticUndefined``,
+so fields become optional. Applying the view to a model only updates values that were set.
 
 .. code-block:: python
 
@@ -168,7 +172,7 @@ not set (use default value) will not be applied to the model.
    assert updated_model.field_str == "new_data"
 
 
-But if a field is not set on update view, the original value is kept.
+If a field is not set on the update view, the original value is kept.
 
 .. code-block:: python
 

--- a/Version.mk
+++ b/Version.mk
@@ -1,5 +1,12 @@
 
 
+version-help:
+	@echo "Versioning targets"
+	@echo "-----------------------------------------------------------------------"
+	@printf "%-22s %s\n" "version-help" "Show this help"
+	@printf "%-22s %s\n" "version" "Show current version"
+	@printf "%-22s %s\n" "version-set.<version>" "Set new version and show it"
+
 version:
 	@${BUILDER_EXECUTABLE} version --short
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,7 @@ BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) | sed 's/make target/make docs\.target/g'
 
 .PHONY: help Makefile
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,7 @@
 
 from importlib import metadata
 
-project = "View for Pydantic models"
+project = "Views for Pydantic models"
 copyright = "2025, Alfred Santacatalina"
 author = "Alfred Santacatalina"
 release = metadata.version("pydantic-views")

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,0 +1,161 @@
+========
+Examples
+========
+
+
+Minimal create/load/update
+--------------------------
+
+Build common views from a single model and use them as function signatures.
+
+.. code-block:: python
+
+   from pydantic import BaseModel
+   from pydantic_views import BuilderCreate, BuilderCreateResult, BuilderLoad, BuilderUpdate
+
+   class User(BaseModel):
+	   id: int
+	   email: str
+	   password: str
+
+   UserCreate = BuilderCreate().build_view(User)
+   UserCreateResult = BuilderCreateResult().build_view(User)
+   UserLoad = BuilderLoad().build_view(User)
+   UserUpdate = BuilderUpdate().build_view(User)
+
+   def create_user(input: UserCreate) -> UserCreateResult: ...
+   def get_user(user_id: int) -> UserLoad: ...
+   def update_user(user_id: int, input: UserUpdate) -> UserLoad: ...
+
+
+Nested models and selective fields
+----------------------------------
+
+Views cascade into nested models and respect access modes you annotate.
+
+.. code-block:: python
+
+   from typing import Annotated
+
+   from pydantic import BaseModel, computed_field
+   from pydantic_views import AccessMode, ReadOnly, ReadOnlyOnCreation, BuilderLoad
+
+   class Address(BaseModel):
+	   street: str
+	   city: str
+	   zip_code: str
+
+   class Profile(BaseModel):
+	   username: str
+	   email: ReadOnly[str]
+	   # Hide on create/update, show after creation
+	   api_token: ReadOnlyOnCreation[str]
+	   # Expose only when reading (load views)
+	   score: Annotated[int, AccessMode.READ_ONLY]
+
+	   @computed_field
+	   def location(self) -> str:
+		   return f"{self.username} @ {self.email}"
+
+	   address: Address
+
+   ProfileLoad = BuilderLoad().build_view(Profile)
+
+   profile = Profile(
+	   username="alice",
+	   email="alice@example.com",
+	   api_token="secret",
+	   score=42,
+	   address=Address(street="Main", city="Springfield", zip_code="00000"),
+   )
+
+   loaded = ProfileLoad.view_build_from(profile)
+   assert loaded.address.city == "Springfield"
+   # api_token and score are present, write-only fields would have been stripped
+
+
+Applying partial updates
+------------------------
+
+Update views accept only the fields you want to change and merge them into an instance.
+
+.. code-block:: python
+
+   from pydantic import BaseModel
+   from pydantic_views import BuilderUpdate
+
+   class Settings(BaseModel):
+	   theme: str
+	   locale: str
+	   marketing_opt_in: bool
+
+   SettingsUpdate = BuilderUpdate().build_view(Settings)
+
+   current = Settings(theme="light", locale="en", marketing_opt_in=False)
+   patch = SettingsUpdate(theme="dark")
+
+   updated = patch.view_apply_to(current)
+
+   assert updated.theme == "dark"
+   assert updated.locale == "en"  # unchanged
+
+
+Create + result pair with computed fields
+-----------------------------------------
+
+Use ``BuilderCreate`` to accept input and ``BuilderCreateResult`` to return read-only and computed fields.
+
+.. code-block:: python
+
+   from pydantic import BaseModel, computed_field
+   from pydantic_views import BuilderCreate, BuilderCreateResult, ReadOnly
+
+   class Invoice(BaseModel):
+	   id: ReadOnly[int]
+	   description: str
+	   units: int
+	   unit_price: float
+
+	   @computed_field
+	   def total(self) -> float:
+		   return self.units * self.unit_price
+
+   InvoiceCreate = BuilderCreate().build_view(Invoice)
+   InvoiceCreateResult = BuilderCreateResult().build_view(Invoice)
+
+   new_invoice = InvoiceCreate(description="Hosting", units=2, unit_price=25.0)
+   stored = Invoice(id=1, **new_invoice.model_dump())
+
+   result = InvoiceCreateResult.view_build_from(stored)
+   assert result.total == 50.0
+
+
+Custom builder with nullable fields
+-----------------------------------
+
+Craft a bespoke builder to allow nullable fields and expose only certain access modes.
+
+.. code-block:: python
+
+   from pydantic import BaseModel
+   from pydantic_views import Builder, AccessMode
+
+   SoftDeleteBuilder = Builder(
+	   view_name="SoftDelete",
+	   access_modes=(AccessMode.READ_AND_WRITE,),
+	   all_nullable=True,
+   )
+
+   class Document(BaseModel):
+	   title: str
+	   body: str
+	   deleted_at: float | None
+
+   DocumentSoftDelete = SoftDeleteBuilder.build_view(Document)
+
+   doc = Document(title="Plan", body="...")
+   soft_delete = DocumentSoftDelete(deleted_at=1720000000.0)
+
+   deleted_doc = soft_delete.view_apply_to(doc)
+   assert deleted_doc.deleted_at is not None
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,3 +6,4 @@
    :maxdepth: 2
 
    api
+   examples

--- a/src/pydantic_views/__init__.py
+++ b/src/pydantic_views/__init__.py
@@ -1,3 +1,10 @@
+"""
+Public package surface for pydantic-views.
+
+This module re-exports the main classes, builders, and annotations so users can import
+from :mod:`pydantic_views` directly.
+"""
+
 from .annotations import (
     AccessMode,
     Hidden,

--- a/src/pydantic_views/annotations.py
+++ b/src/pydantic_views/annotations.py
@@ -1,3 +1,10 @@
+"""
+Helpers to annotate Pydantic fields with access modes used by pydantic-views builders.
+
+These annotations tell the builders whether a field should be exposed for read, write,
+creation-only flows, or hidden entirely.
+"""
+
 from enum import Enum, auto
 from typing import Annotated, TypeVar
 
@@ -5,9 +12,7 @@ T = TypeVar("T")
 
 
 class AccessMode(Enum):
-    """
-    Field access mode.
-    """
+    """Access rules that determine if and when a field is exposed in generated views."""
 
     #: Read and write mark.
     READ_AND_WRITE = auto()

--- a/src/pydantic_views/builder.py
+++ b/src/pydantic_views/builder.py
@@ -23,9 +23,7 @@ from .view import RootView, View
 
 
 class Builder:
-    """
-    View builder. It create a view classes from models following given criteria.
-    """
+    """Factory for generating view classes from Pydantic models based on access rules."""
 
     def __init__(
         self,
@@ -37,12 +35,12 @@ class Builder:
         include_computed_fields: bool = False,
     ) -> None:
         """
-        :param view_name: View name.
-        :param access_modes: Access modes to filter for.
-        :param all_optional: Make all fields optionals. On updates it allows to send just fields you want to change.
-        :param all_nullable: Make all fields nullable. On some kinds of updates it could meant set default value.
-        :param hide_default_null: Hide :obj:`None` as default value. It produces better examples.
-        :param include_computed_fields: Whether computed fields must be included on view or not.
+        :param view_name: Name suffix for the generated view class.
+        :param access_modes: Access modes that the builder will include in generated views.
+        :param all_optional: Make all fields optional (useful for update scenarios).
+        :param all_nullable: Make all fields nullable when allowed.
+        :param hide_default_null: Replace default ``None`` with ``PydanticUndefined`` to hide ``null`` in schemas.
+        :param include_computed_fields: Whether computed fields should be included in generated views.
         """
         self.view_name = view_name
         self.access_modes = access_modes
@@ -54,10 +52,10 @@ class Builder:
 
     def build_view[T: BaseModel](self, model: type[T]) -> type[View[T] | T]:
         """
-        Builds a view from model if it does not exist, otherwise it return already created one.
+        Build or return a cached view for the given model.
 
-        :param model: Model class.
-        :returns: View of model class.
+        :param model: Model class to derive the view from.
+        :returns: View class associated to ``model`` for this builder.
         """
         manager = ensure_model_views(model)
         try:
@@ -75,12 +73,10 @@ class Builder:
 
     def get_view_ref[T: BaseModel](self, model: type[T]) -> type[View[T] | T] | ForwardRef:
         """
-        Returns a view of model or a forward reference to it.
+        Return the view class or a forward reference for the model.
 
-        :param model: Model class.
-        :type model: type[T]
-        :returns: View of model class or reference to it.
-        :rtype: type[View[T] | T] | ForwardRef
+        :param model: Model class to derive the view from.
+        :returns: View class or forward reference for ``model``.
         """
         try:
             return cast(type[View[T]] | ForwardRef, self._views[model])
@@ -119,10 +115,10 @@ class Builder:
 
     def build_from_model[T: BaseModel](self, model: type[T]) -> type[View[T] | T]:
         """
-        Builds a view from model
+        Build the concrete view class from the provided model.
 
-        :param model: Model class.
-        :returns: View of model class.
+        :param model: Model class to derive the view from.
+        :returns: Generated view class for the model.
         """
         from pydantic._internal._config import ConfigWrapper  # type: ignore
 
@@ -300,13 +296,15 @@ class Builder:
 
 def BuilderCreate(view_name: str = "Create") -> Builder:
     """
-    Default builder for `Create` view. Views created by it keep fields with
-    :obj:`access mode <pydantic_views.AccessMode>` :obj:`~pydantic_views.AccessMode.READ_AND_WRITE`,
-    :obj:`~pydantic_views.AccessMode.WRITE_ONLY` and :obj:`~pydantic_views.AccessMode.WRITE_ONLY_ON_CREATION`.
-    And hide default :obj:`None` value. It produces a better schema examples.
+    Default builder for ``Create`` views.
+
+    Keeps fields with :obj:`access mode <pydantic_views.AccessMode>`
+    :obj:`~pydantic_views.AccessMode.READ_AND_WRITE`,
+    :obj:`~pydantic_views.AccessMode.WRITE_ONLY`, and
+    :obj:`~pydantic_views.AccessMode.WRITE_ONLY_ON_CREATION`, hiding default ``None`` values.
 
     :param view_name: View name.
-    :returns: Builder configured for `Create` views.
+    :returns: Builder configured for ``Create`` views.
     """
     return Builder(
         view_name,
@@ -321,13 +319,15 @@ def BuilderCreate(view_name: str = "Create") -> Builder:
 
 def BuilderCreateResult(view_name: str = "CreateResult") -> Builder:
     """
-    Default builder for `CreateResult` view. Views created by it keep fields with
-    :obj:`access mode <pydantic_views.AccessMode>` :obj:`~pydantic_views.AccessMode.READ_AND_WRITE`,
-    :obj:`~pydantic_views.AccessMode.READ_ONLY` and :obj:`~pydantic_views.AccessMode.READ_ONLY_ON_CREATION`.
-    And includes computed fields.
+    Default builder for ``CreateResult`` views.
+
+    Keeps fields with :obj:`access mode <pydantic_views.AccessMode>`
+    :obj:`~pydantic_views.AccessMode.READ_AND_WRITE`,
+    :obj:`~pydantic_views.AccessMode.READ_ONLY`, and
+    :obj:`~pydantic_views.AccessMode.READ_ONLY_ON_CREATION`, and includes computed fields.
 
     :param view_name: View name.
-    :returns: Builder configured for `CreateResult` views.
+    :returns: Builder configured for ``CreateResult`` views.
     """
     return Builder(
         view_name,
@@ -342,12 +342,14 @@ def BuilderCreateResult(view_name: str = "CreateResult") -> Builder:
 
 def BuilderUpdate(view_name: str = "Update") -> Builder:
     """
-    Default builder for `Update` view. Views created by it keep fields with
-    :obj:`access mode <pydantic_views.AccessMode>` :obj:`~pydantic_views.AccessMode.READ_AND_WRITE`
-    and :obj:`~pydantic_views.AccessMode.WRITE_ONLY`. And make all fields optional.
+    Default builder for ``Update`` views.
+
+    Keeps fields with :obj:`access mode <pydantic_views.AccessMode>`
+    :obj:`~pydantic_views.AccessMode.READ_AND_WRITE` and
+    :obj:`~pydantic_views.AccessMode.WRITE_ONLY`, and makes all fields optional.
 
     :param view_name: View name.
-    :returns: Builder configured for `Update` views.
+    :returns: Builder configured for ``Update`` views.
     """
     return Builder(
         view_name,
@@ -358,12 +360,14 @@ def BuilderUpdate(view_name: str = "Update") -> Builder:
 
 def BuilderLoad(view_name: str = "Load") -> Builder:
     """
-    Default builder for `Load` view. Views created by it keep fields with
-    :obj:`access mode <pydantic_views.AccessMode>` :obj:`~pydantic_views.AccessMode.READ_AND_WRITE`
-    and :obj:`~pydantic_views.AccessMode.READ_ONLY`. And includes computed fields.
+    Default builder for ``Load`` views.
+
+    Keeps fields with :obj:`access mode <pydantic_views.AccessMode>`
+    :obj:`~pydantic_views.AccessMode.READ_AND_WRITE` and
+    :obj:`~pydantic_views.AccessMode.READ_ONLY`, and includes computed fields.
 
     :param view_name: View name.
-    :returns: Builder configured for `Load` views.
+    :returns: Builder configured for ``Load`` views.
     """
     return Builder(
         view_name,
@@ -380,7 +384,7 @@ def ensure_model_views[T: BaseModel](model: type[T]):
     Ensures model has a view manager and returns it.
 
     :param model: Model class.
-    :returns: Views manager for model class.
+    :returns: Views manager for the model class.
     """
 
     try:

--- a/src/pydantic_views/manager.py
+++ b/src/pydantic_views/manager.py
@@ -10,14 +10,16 @@ if TYPE_CHECKING:
 
 
 class Manager[TModel: BaseModel]:
-    """
-    Views manager for a given model class.
-    """
+    """Registry and factory for views derived from a model class."""
 
     __slots__ = ("_model", "_views")
 
     def __init__(self, model: type[TModel]):
-        """ """
+        """
+        Initialize a manager for the given model type.
+
+        :param model: Base model class that views will be derived from.
+        """
         self._model = ref(model)
         self._views: dict[str, type[View[TModel] | TModel]] = {}
 
@@ -26,7 +28,7 @@ class Manager[TModel: BaseModel]:
         """
         Associated model class.
 
-        :returns: Model class associated.
+        :returns: Model class associated with this manager.
         """
         result = self._model()
         if not result:  # pragma: no cover
@@ -38,7 +40,7 @@ class Manager[TModel: BaseModel]:
         Get a model view.
 
         :param view_name: Name of view to get.
-        :returns: View of model class.
+        :returns: View class registered under ``view_name``.
         """
         return self._views[view_name]
 
@@ -46,8 +48,8 @@ class Manager[TModel: BaseModel]:
         """
         Set a model view.
 
-        :param view_name: Name of view to get.
-        :param view: View of model class.
+        :param view_name: Name to register the view under.
+        :param view: View class to associate with the name.
         """
         self._views[view_name] = view
 
@@ -55,8 +57,8 @@ class Manager[TModel: BaseModel]:
         """
         Build view class for Manager's model.
 
-        :param builder: Builder to use to make the view of model.
-        :returns: View of model class.
+        :param builder: Builder used to generate the view for the managed model.
+        :returns: Newly built view class registered under the builder name.
         """
         view = builder.build_from_model(self.model)
         self[builder.view_name] = view

--- a/src/pydantic_views/view.py
+++ b/src/pydantic_views/view.py
@@ -6,9 +6,7 @@ from pydantic import BaseModel, RootModel
 
 
 class View[T: BaseModel](BaseModel):
-    """
-    View of model.
-    """
+    """Lightweight view over a base Pydantic model with helper builders and mergers."""
 
     __model_class_root__: ClassVar[ReferenceType[type[BaseModel]]]
 
@@ -24,9 +22,9 @@ class View[T: BaseModel](BaseModel):
     @classmethod
     def view_class_root(cls) -> type[T]:
         """
-        Returns the class object associated to the view.
+        Return the base model class this view was generated from.
 
-        :returns: Associated model class.
+        :returns: Associated base model class.
         """
 
         root = cls.__model_class_root__()
@@ -39,18 +37,18 @@ class View[T: BaseModel](BaseModel):
     @classmethod
     def view_build_from(cls, model: T):
         """
-        Build view from given model.
+        Create a view instance from a model instance, omitting unset fields.
 
-        :param model: Model class to build view from.
-        :returns: View of model class.
+        :param model: Model instance to build the view from.
+        :returns: View populated with the model data.
         """
         return cls.model_validate(model.model_dump(exclude_unset=True, by_alias=True))
 
     def view_build_to(self) -> T:
         """
-        Build associated model from view data.
+        Build the associated model instance using only fields set on the view.
 
-        :returns: Associated model instance with view data.
+        :returns: Model instance created from the view data.
         """
 
         return self.view_class_root().model_validate(
@@ -59,24 +57,26 @@ class View[T: BaseModel](BaseModel):
 
     def view_apply_to(self, model: T) -> T:
         """
-        Apply view data to associated model.
+        Merge the view data into an existing model instance, returning a copy.
 
-        :param model: Model instance to use as base..
-        :returns: Associated model instance with view data merged to given model data.
+        :param model: Model instance used as the base.
+        :returns: New model instance with the view data applied.
         """
 
         return model_apply(model, self)
 
 
 class RootView[R](View[RootModel[R]], RootModel[R]):
-    """
-    View for root models.
-    """
+    """View wrapper specialized for ``RootModel`` instances."""
 
 
 def model_apply[T: BaseModel](orig: T, view: View[T] | T) -> T:
     """
-    Merge view or model into model
+    Return a copy of ``orig`` updated with fields set on ``view`` (model or view).
+
+    :param orig: Original model instance to update.
+    :param view: View or model supplying updated values.
+    :returns: New model instance with merged data.
     """
 
     update_data: dict[str, Any] = {}


### PR DESCRIPTION
This pull request improves both the user and developer experience of the `pydantic-views` package. The documentation has been rewritten for clarity, with a more approachable README, a new comprehensive examples section, and improved quickstart instructions. The Makefile and build configuration have been refactored for clearer help output and modernized to support the `uv` package manager. Additionally, the public API and docstrings have been enhanced for better usability and discoverability.

**Documentation improvements:**

* Rewrote the `README.rst` to clarify the purpose of the package, provide a concise quickstart, and improve explanations and examples of usage and field annotations. [[1]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL23-R31) [[2]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL49-R53) [[3]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fR72-R123) [[4]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL131-R155) [[5]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL171-R175)
* Added a new `docs/source/examples.rst` file with detailed, practical code examples covering common and advanced use cases. Linked this new examples page from the documentation index. [[1]](diffhunk://#diff-a7edaa326e0e91de9c1d6ee49809f1a52b99e3a564d40802909fe7bc1f00c14fR1-R161) [[2]](diffhunk://#diff-4eec6cec5f6fab1548b85433ea8ca81315ae165db4b7f84019f287df9015699fR9)
* Updated project name in documentation and metadata to "Views for Pydantic models" for consistency.

**Build and Makefile improvements:**

* Modernized `.readthedocs.yaml` to use Python 3.14 and the `uv` package manager for faster, reproducible builds.
* Improved Makefile targets: added `.PHONY` declarations, standardized help output using `printf`, and added a `version-help` target for versioning commands. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R6-R15) [[2]](diffhunk://#diff-ca9b0014c0c1776bf1d72898b323346131fcab4abc7e82917760a501a5f31195R3-R9) [[3]](diffhunk://#diff-5985cce875f06353bd77eeaa0070d622fee6bf12c41aaa64d87a325c14796f5cL24-R37)
* Updated `docs/Makefile` help output to clarify documentation-specific targets.

**Public API and docstring enhancements:**

* Added module-level docstrings to `src/pydantic_views/__init__.py` and `src/pydantic_views/annotations.py` to clarify the public API and the purpose of field annotations. [[1]](diffhunk://#diff-81d1f2d3498ca54dac087ad25d2bc25dc70271367a1f9b9166e88c41e1df97c6R1-R7) [[2]](diffhunk://#diff-665b801ea35f259a521688e6ab438939c80de2bd82bd7eb397372200c5ba1f4fR1-R15)
* Improved docstrings throughout `src/pydantic_views/builder.py` for all classes and methods, making the API easier to understand and use. [[1]](diffhunk://#diff-0b7d34ad82be27de793c2d33988db3e053a7166cbf4f6b14bfd15270e3fee066L26-R26) [[2]](diffhunk://#diff-0b7d34ad82be27de793c2d33988db3e053a7166cbf4f6b14bfd15270e3fee066L40-R43) [[3]](diffhunk://#diff-0b7d34ad82be27de793c2d33988db3e053a7166cbf4f6b14bfd15270e3fee066L57-R58) [[4]](diffhunk://#diff-0b7d34ad82be27de793c2d33988db3e053a7166cbf4f6b14bfd15270e3fee066L78-R79) [[5]](diffhunk://#diff-0b7d34ad82be27de793c2d33988db3e053a7166cbf4f6b14bfd15270e3fee066L122-R121) [[6]](diffhunk://#diff-0b7d34ad82be27de793c2d33988db3e053a7166cbf4f6b14bfd15270e3fee066L303-R307)