### PR TITLE
Update actions and use own token to create prs

### DIFF
--- a/.github/actions/setup-repo/action.yaml
+++ b/.github/actions/setup-repo/action.yaml
@@ -18,7 +18,7 @@ runs:
         version: ${{ inputs.uv-version }}
         python-version: ${{ inputs.python-version }}
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       name: Define a cache for the virtual environment based on the dependencies lock file
       with:
         path: ./.venv

--- a/.github/workflows/common_get_version.yaml
+++ b/.github/workflows/common_get_version.yaml
@@ -80,7 +80,7 @@ jobs:
       is-prerelease: ${{ steps.define-version.outputs.is-prerelease }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}

--- a/.github/workflows/common_make_release.yaml
+++ b/.github/workflows/common_make_release.yaml
@@ -24,7 +24,7 @@ jobs:
       release-ref: release/${{ steps.define-version.outputs.release-minor }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/common_push_version.yaml
+++ b/.github/workflows/common_push_version.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
@@ -46,7 +46,7 @@ jobs:
           level: ${{ inputs.level }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           title: "Bump version to ${{ steps.define-version.outputs.version }}"
           branch: "task/start-version-${{ steps.define-version.outputs.version }}"
@@ -56,4 +56,5 @@ jobs:
             :crown: *Automatic PR starting new version*
           labels: automated,bot
           base: ${{ inputs.ref }}
-          add-paths: pyproject.toml         
+          add-paths: pyproject.toml        
+          token: ${{ secrets.ACTION_GITHUB_TOKEN }} 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
           


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use newer versions of key actions and improves the configuration for creating pull requests and caching dependencies. The main focus is on maintaining up-to-date dependencies and ensuring compatibility with the latest features and security updates in GitHub Actions.

**GitHub Actions Version Upgrades:**

* Updated all occurrences of `actions/checkout` from version `v4` to `v6` in `.github/workflows/common_get_version.yaml`, `.github/workflows/common_make_release.yaml`, `.github/workflows/common_push_version.yaml`, and `.github/workflows/pull_request.yaml` to ensure the latest features and security patches are used. [[1]](diffhunk://#diff-e7fb3fef88b945b5dae07ddfc26d17e06842ce5e33ff78a67b63e5926575b3c6L83-R83) [[2]](diffhunk://#diff-6e7c604bc726c98bd4c0b9795ec3778651b6d545ec515386fb822b3d99d0b3b7L27-R27) [[3]](diffhunk://#diff-f160bdd39d6839456f9472e81ba9e0a2b3ff54d0f0ed457d52852cf5355c8cf4L36-R36) [[4]](diffhunk://#diff-7b2a967de7060a238e49a57908f83e860b8cb53a0b0991c3d0d275857c1014d4L35-R35)
* Upgraded `actions/cache` from `v4` to `v5` in `.github/actions/setup-repo/action.yaml` to benefit from improved caching capabilities and bug fixes.
* Updated `peter-evans/create-pull-request` from `v7` to `v8` in `.github/workflows/common_push_version.yaml` for enhanced pull request automation and compatibility.

**Workflow Configuration Improvements:**

* Added the `token` input to the `peter-evans/create-pull-request` step in `.github/workflows/common_push_version.yaml` to explicitly use the `ACTION_GITHUB_TOKEN` secret, which can help with authentication and permissions for automated PR creation.