### PR TITLE
Add uv.lock to commit

### DIFF
--- a/.github/workflows/common_push_version.yaml
+++ b/.github/workflows/common_push_version.yaml
@@ -56,5 +56,7 @@ jobs:
             :crown: *Automatic PR starting new version*
           labels: automated,bot
           base: ${{ inputs.ref }}
-          add-paths: pyproject.toml        
+          add-paths: |
+            pyproject.toml 
+            uv.lock       
           token: ${{ secrets.ACTION_GITHUB_TOKEN }} 


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration by ensuring that both the `pyproject.toml` and `uv.lock` files are tracked for changes that trigger the workflow. This helps ensure versioning automation works correctly when either of these files is updated.