### PR TITLE
feat(typing): Added stubgen script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ docs/build
 .venv
 
 uv.lock
+
+pytest.xml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,6 @@ build:
     create_environment:
       - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
     install:
-      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --group docs
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --group docs
 sphinx:
   configuration: docs/source/conf.py

--- a/README.rst
+++ b/README.rst
@@ -519,8 +519,8 @@ stub generator. It imports your module and writes a ``.pyi`` describing every vi
 
    python -m pydantic_views.stubgen myapp.models
 
-Pass a package name to stub every submodule, and ``-o/--output-dir`` to write the stubs to a separate
-tree. See
+Pass a package name to stub every submodule, list several modules at once, and use ``-o/--output-dir``
+to write the stubs to a separate tree. See
 `Type checking and stub files <https://pydantic-views.readthedocs.io/stable/type_checking.html>`_
 for the stub generator and mypy plugin options, and the full list of what is and isn't analysed
 statically.

--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,7 @@ Features
 - Custom access tags for fine-grained, per-view field selection.
 - Helpers to build a view from a model, build a model from a view, and merge a view into a model.
 - Fully typed with a shipped ``py.typed`` marker and an extensive test suite.
+- Static type checking via a bundled mypy plugin and a ``.pyi`` stub generator for other type checkers.
 - Open source and published on PyPI.
 
 
@@ -510,10 +511,18 @@ fields with their generated views (``Address`` + ``Load`` -> ``AddressLoad``):
    reveal_type(UserLoad.model_validate({}).id)   # int — the plugin knows the field exists
    UserLoad(password="secret")                    # error: write-only field is not in a load view
 
-For type checkers that don't run mypy plugins (pyright, PyCharm, …) you can turn the plugin's output
-into ``.pyi`` stubs. See
+For type checkers that don't run mypy plugins (pyright, Pylance, PyCharm, …), pydantic-views ships a
+stub generator. It imports your module and writes a ``.pyi`` describing every view's real fields
+(plus the regular classes, models and functions around them):
+
+.. code-block:: bash
+
+   python -m pydantic_views.stubgen myapp.models
+
+Pass a package name to stub every submodule, and ``-o/--output-dir`` to write the stubs to a separate
+tree. See
 `Type checking and stub files <https://pydantic-views.readthedocs.io/stable/type_checking.html>`_
-for the plugin options, the stub-generation CLI, and the full list of what is and isn't analysed
+for the stub generator and mypy plugin options, and the full list of what is and isn't analysed
 statically.
 
 

--- a/docs/source/type_checking.rst
+++ b/docs/source/type_checking.rst
@@ -105,12 +105,13 @@ describing their real fields. Run it as a module, passing the importable name of
    wrote /path/to/myapp/models.pyi
 
 By default the stub is written next to its source file (``models.py`` -> ``models.pyi``). Pass a
-**package** name to walk every submodule, and use ``-o`` / ``--output-dir`` to mirror the package
-tree into a separate directory instead of writing the stubs in place:
+**package** name to walk every submodule, list **several modules** at once, and use ``-o`` /
+``--output-dir`` to mirror the package tree into a separate directory instead of writing the stubs in
+place:
 
 .. code-block:: console
 
-   $ python -m pydantic_views.stubgen myapp --output-dir build/stubs
+   $ python -m pydantic_views.stubgen myapp.models myapp.schemas --output-dir build/stubs
 
 Wire either command into a pre-commit hook or a ``make`` target to keep the stubs in sync with your
 models.

--- a/docs/source/type_checking.rst
+++ b/docs/source/type_checking.rst
@@ -84,6 +84,9 @@ A few things cannot be recovered statically:
 * A view must be declared in the **same module** as its source model, because mypy frees the
   annotations of imported modules.
 
+These limits apply to the mypy plugin only. The runtime stub generator described below is not subject
+to any of them, because it reads the views' real fields after import.
+
 
 Generating stub files for other type checkers
 ==============================================
@@ -92,109 +95,42 @@ Type checkers that do not run mypy plugins (pyright, Pylance, PyCharm) see a vie
 with an ``__init__(**data: Any)`` signature. Plain ``stubgen`` does not help either: it does not
 execute mypy plugins, so it produces the same empty view.
 
-The reliable approach is to drive mypy's build API **with the plugin enabled**, read the synthesised
-``__init__`` of each view, and write a ``.pyi`` stub from it. pydantic-views does not ship a console
-command for this, but the generator is small enough to keep as a script in your project. Save the
-following as, for example, ``gen_view_stubs.py``:
-
-.. code-block:: python
-
-   """Generate a .pyi stub of pydantic-views views, using the mypy plugin."""
-
-   from __future__ import annotations
-
-   import argparse
-   from pathlib import Path
-
-   from mypy import build
-   from mypy.modulefinder import BuildSource
-   from mypy.nodes import FuncDef, TypeInfo
-   from mypy.options import Options
-   from mypy.types import CallableType, Instance, get_proper_type
-
-   from pydantic_views.mypy import ROOTVIEW_FULLNAME, VIEW_FULLNAME
-
-   def render(typ) -> str:
-       typ = get_proper_type(typ)
-       if isinstance(typ, Instance):
-           if typ.args:
-               return f"{typ.type.name}[{', '.join(render(a) for a in typ.args)}]"
-           return typ.type.name
-       return "Any" if typ is None else str(typ)
-
-   def stub_for(info: TypeInfo) -> str:
-       # The plugin synthesises an __init__ whose keyword-only parameters are exactly the view's
-       # fields (source-model fields kept by the access rules, plus any declared on the view body).
-       lines = [f"class {info.name}(View[{render(info.bases[0].args[0])}]):"]
-       init = info.names.get("__init__")
-       if init and isinstance(init.node, FuncDef) and isinstance(init.node.type, CallableType):
-           sig = init.node.type
-           for name, typ, kind in zip(sig.arg_names, sig.arg_types, sig.arg_kinds):
-               if name in (None, "self", "__pydantic_self__") or kind.is_star():
-                   continue
-               default = " = ..." if kind.is_optional() else ""
-               lines.append(f"    {name}: {render(typ)}{default}")
-       return "\n".join(lines)
-
-   def main() -> None:
-       parser = argparse.ArgumentParser(description=__doc__)
-       parser.add_argument("--module", required=True, help="dotted module that declares the views")
-       parser.add_argument("--source", required=True, type=Path, help="path to that module's .py file")
-       parser.add_argument("--config", required=True, type=Path, help="mypy config (its [pydantic-views-mypy] options are honoured)")
-       parser.add_argument("--root", type=Path, default=Path.cwd(), help="import root (default: current directory)")
-       parser.add_argument("--output", type=Path, help="stub path (default: --source with a .pyi suffix)")
-       args = parser.parse_args()
-
-       options = Options()
-       # build.build() does NOT read the config file for the plugin list, so set it explicitly
-       # (pydantic_views.mypy must come before pydantic.mypy):
-       options.plugins = ["pydantic_views.mypy", "pydantic.mypy"]
-       options.config_file = str(args.config.resolve())
-       options.incremental = False
-       options.namespace_packages = True
-       options.explicit_package_bases = True
-       options.mypy_path = [str(args.root.resolve())]  # absolute paths; relative ones break resolution
-       result = build.build([BuildSource(str(args.source.resolve()), args.module, None)], options)
-
-       tree = result.graph[args.module].tree
-       if tree is None:
-           raise SystemExit(f"mypy did not analyse {args.module!r}")
-
-       blocks = ["from typing import Any, Literal\n\nfrom pydantic_views import View\n"]
-       for sym in tree.names.values():
-           node = sym.node
-           if (
-               isinstance(node, TypeInfo)
-               and node.has_base(VIEW_FULLNAME)
-               and node.fullname not in (VIEW_FULLNAME, ROOTVIEW_FULLNAME)
-           ):
-               blocks.append(stub_for(node))
-
-       out = args.output or args.source.with_suffix(".pyi")
-       out.write_text("\n\n".join(blocks) + "\n")
-       print(f"wrote {out}")
-
-   if __name__ == "__main__":
-       main()
-
-Run it from the command line, pointing it at the module that declares your views, that module's
-file, and your mypy config:
+pydantic-views ships its own stub generator, :mod:`pydantic_views.stubgen`, that solves this without
+mypy. It **imports** the target module, inspects the views at runtime, and writes a ``.pyi`` stub
+describing their real fields. Run it as a module, passing the importable name of the module to stub:
 
 .. code-block:: console
 
-   $ python gen_view_stubs.py \
-       --module myapp.models \
-       --source src/myapp/models.py \
-       --config mypy.ini \
-       --root src \
-       --output src/myapp/models.pyi
-   wrote src/myapp/models.pyi
+   $ python -m pydantic_views.stubgen myapp.models
+   wrote /path/to/myapp/models.pyi
 
-Drop the ``--output`` flag to write the stub next to ``--source`` (``models.py`` -> ``models.pyi``),
-and adjust ``--root`` to whatever directory is on your import path (often ``.`` or ``src``). Wire the
-command into a pre-commit hook or a ``make`` target to keep the stub in sync with your models.
+By default the stub is written next to its source file (``models.py`` -> ``models.pyi``). Pass a
+**package** name to walk every submodule, and use ``-o`` / ``--output-dir`` to mirror the package
+tree into a separate directory instead of writing the stubs in place:
 
-For a model like:
+.. code-block:: console
+
+   $ python -m pydantic_views.stubgen myapp --output-dir build/stubs
+
+Wire either command into a pre-commit hook or a ``make`` target to keep the stubs in sync with your
+models.
+
+
+What the stub contains
+----------------------
+
+Because the generator works from the imported module, each stub is a **complete** description of that
+module, not just its views:
+
+* every regular class — plain classes, enums (including ones nested inside a model), and Pydantic
+  models, with ``@computed_field`` properties rendered as read-only properties;
+* every view declared in the module;
+* every view **generated at runtime**, including the nested views built for referenced models
+  (``Address`` + ``Load`` -> ``AddressLoad``);
+* module-level functions, preserving PEP 695 type parameters.
+
+Each view is emitted with its real field set and a keyword-only ``__init__``, so other type checkers
+resolve attributes and constructor calls exactly as the mypy plugin would. For a model like:
 
 .. code-block:: python
 
@@ -206,26 +142,31 @@ For a model like:
    class AccountLoad(View[Account], preset=LoadPreset):
        pass
 
-the script emits a stub that other type checkers can read:
+the generator emits both the model and the view:
 
 .. code-block:: python
+
+   class Account(BaseModel):
+       id: int
+       username: str
+       password: str
+       def __init__(self, *, id: int, username: str, password: str) -> None: ...
 
    class AccountLoad(View[Account]):
        id: int
        username: str
        def __init__(self, *, id: int, username: str) -> None: ...
 
-.. warning::
+Reproducing the whole module is deliberate: a type checker treats an adjacent ``<module>.pyi`` as the
+complete description of the module and ignores the ``.py``, so a stub that listed only the views would
+hide every other symbol. Because the generator emits the regular classes, models, functions and views
+together, you can point it at any module — there is no need to isolate views in a dedicated module.
 
-   A type checker treats an adjacent ``<module>.pyi`` as the **complete** description of the module
-   and ignores the ``.py`` entirely. A stub that contains only the views would therefore hide every
-   other symbol (the source models, functions, constants, …). To avoid that, either:
+Because it reflects the runtime model rather than a static analysis, the generator also captures the
+views the mypy plugin cannot recover: those built with the ``**Preset._asdict()`` splat, views
+declared in a different module from their source model, and
+:class:`~pydantic_views.AccessTag` ``include_tags`` / ``exclude_tags`` filtering.
 
-   * declare your views in a **dedicated module** (e.g. ``views.py``) so its ``views.pyi`` only needs
-     to describe the views, or
-   * generate the rest of the module with ``stubgen`` first and splice the view classes from the
-     script into that complete stub.
-
-A complete, working reference — including readable type rendering, nested views, and a check that the
-stub's field set matches the runtime ``model_fields`` — lives in
+A runnable reference that stubs the bundled example models and verifies the generated field sets
+against the runtime ``model_fields`` lives in
 `examples/generate_stubs.py <https://github.com/alfred82santa/pydantic-views/blob/main/examples/generate_stubs.py>`_.

--- a/examples/models.py
+++ b/examples/models.py
@@ -26,10 +26,14 @@ from pydantic import BaseModel, Field, computed_field
 
 from pydantic_views import (
     AccessMode,
+    AccessTag,
+    CreatePreset,
     Hidden,
     LoadPreset,
+    Preset,
     ReadOnly,
     ReadOnlyOnCreation,
+    UpdatePreset,
     View,
     WriteOnly,
     WriteOnlyOnCreation,
@@ -224,3 +228,28 @@ class AccountLoad(View[Account], preset=LoadPreset):
     keeps exactly the readable fields (``id``, ``username``) and drops write-only ``password`` —
     identical to the explicit-keyword views above.
     """
+
+
+InternalCreatePreset = Preset(
+    view_name="InternalCreate",
+    access_modes=CreatePreset.access_modes,
+    include_tags=(AccessTag("internal-updatable"),),
+    all_optional=CreatePreset.all_optional,
+    all_nullable=CreatePreset.all_nullable,
+    hide_default_null=CreatePreset.hide_default_null,
+    include_computed_fields=CreatePreset.include_computed_fields,
+)
+
+InternalUpdatePreset = Preset(
+    view_name="InternalUpdate",
+    access_modes=UpdatePreset.access_modes,
+    include_tags=(AccessTag("internal-updatable"),),
+    all_optional=UpdatePreset.all_optional,
+    all_nullable=UpdatePreset.all_nullable,
+    hide_default_null=UpdatePreset.hide_default_null,
+    include_computed_fields=UpdatePreset.include_computed_fields,
+)
+
+
+var_int: int = 42
+var_str: str = "hello"

--- a/examples/models.py
+++ b/examples/models.py
@@ -18,6 +18,7 @@ Load              READ_AND_WRITE, READ_ONLY                                     
 from __future__ import annotations
 
 from datetime import datetime
+from enum import StrEnum
 from typing import Annotated, Literal
 
 from annotated_types import Gt
@@ -35,9 +36,24 @@ from pydantic_views import (
 )
 
 
+def get_user_display_name(user: User) -> str:
+    """A function that uses the generated views, to demonstrate that they are fully usable."""
+    user_load = UserLoad.model_validate(user)
+    return user_load.display_name
+
+
+class AddressType(StrEnum):
+    """An enum used to demonstrate that the mypy plugin preserves enum types."""
+
+    HOME = "home"
+    WORK = "work"
+    OTHER = "other"
+
+
 class Address(BaseModel):
     """A nested model referenced by ``User``."""
 
+    type: AddressType
     street: str
     number: int
     zip_code: ReadOnly[str]
@@ -45,6 +61,14 @@ class Address(BaseModel):
 
 
 class Role(BaseModel):
+    class RoleType(StrEnum):
+        """A nested enum used to demonstrate that the mypy plugin preserves nested enums."""
+
+        ADMIN = "admin"
+        USER = "user"
+        GUEST = "guest"
+
+    type: RoleType
     name: str
     level: Annotated[int, AccessMode.READ_ONLY, Gt(0)]
 

--- a/src/pydantic_views/builder.py
+++ b/src/pydantic_views/builder.py
@@ -1,6 +1,5 @@
 from collections.abc import Iterable, Mapping
 from functools import reduce
-from tkinter import NONE
 from types import NoneType, UnionType
 from typing import (
     Annotated,
@@ -226,7 +225,7 @@ class Builder:
 
     def _map_annotation(
         self, annotation: type[Any] | None, *, ignore_nullable: bool = False
-    ) -> type[Any] | ForwardRef | NONE | UnionType:
+    ) -> type[Any] | ForwardRef | None | UnionType:
         def finish_annotation(a: type[Any] | None) -> type[Any] | None | UnionType:
             if not ignore_nullable and self.all_nullable and a is not Ellipsis:  # type: ignore
                 return a | None  # type: ignore

--- a/src/pydantic_views/stubgen.py
+++ b/src/pydantic_views/stubgen.py
@@ -18,15 +18,16 @@ The emitted stub for each module contains:
 Usage::
 
     python -m pydantic_views.stubgen examples.models
-    python -m pydantic_views.stubgen examples.models --output-dir build/stubs
+    python -m pydantic_views.stubgen examples.models examples.other --output-dir build/stubs
 
-By default each ``.pyi`` is written next to its source ``.py``. With ``--output-dir`` the package
-tree is mirrored under the given directory.
+One or more module names may be given. By default each ``.pyi`` is written next to its source ``.py``.
+With ``--output-dir`` the package tree is mirrored under the given directory.
 """
 
 from __future__ import annotations
 
 import argparse
+import ast
 import collections.abc
 import enum
 import importlib
@@ -395,36 +396,115 @@ def _collect_runtime_views(module: types.ModuleType) -> list[type[View[Any]]]:
     return list(views.values())
 
 
+def _target_names(target: ast.expr) -> list[str]:
+    """Return the simple names bound by an assignment target (handling tuple/list unpacking)."""
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, ast.Starred):
+        return _target_names(target.value)
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return [name for elt in target.elts for name in _target_names(elt)]
+    return []
+
+
+def _module_assigned_names(module: types.ModuleType) -> list[str]:
+    """Return the module-level variable names assigned in the source, in definition order.
+
+    Reading the source (rather than ``vars(module)``) is what lets us tell a variable *defined* in
+    the module apart from a name merely *imported* into it: imports are not assignment statements.
+    Class and function definitions are separate node kinds and are emitted elsewhere.
+    """
+    source_path = getattr(module, "__file__", None)
+    if source_path is None:
+        return []
+    try:
+        tree = ast.parse(Path(source_path).read_text())
+    except (OSError, SyntaxError):
+        return []
+
+    names: list[str] = []
+    seen: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.AnnAssign):
+            targets = _target_names(node.target)
+        elif isinstance(node, ast.Assign):
+            targets = [name for target in node.targets for name in _target_names(target)]
+        else:
+            continue
+        for name in targets:
+            if name not in seen and not (name.startswith("__") and name.endswith("__")):
+                seen.add(name)
+                names.append(name)
+    return names
+
+
+def _render_module_variables(module: types.ModuleType, imports: Imports, skip: set[str]) -> list[str]:
+    """Render ``name: type`` lines for module-level variables defined in ``module``.
+
+    Annotated variables use their declared annotation; the rest fall back to the runtime value's type.
+    """
+    try:
+        hints = typing.get_type_hints(module)
+    except Exception:
+        hints = {}
+    raw_annotations = getattr(module, "__annotations__", {})
+
+    lines: list[str] = []
+    for name in _module_assigned_names(module):
+        if name in skip:
+            continue
+        if name in hints:
+            type_str = render_annotation(hints[name], imports)
+        elif name in raw_annotations:
+            type_str = render_annotation(raw_annotations[name], imports)
+        elif name in vars(module):
+            type_str = imports.ref(type(vars(module)[name]))
+        else:
+            continue
+        lines.append(f"{name}: {type_str}")
+    return lines
+
+
 def render_module(module: types.ModuleType) -> str:
     """Render the full ``.pyi`` text for a single module."""
     imports = Imports(module.__name__)
     emitted: set[int] = set()
+    emitted_names: set[str] = set()
     blocks: list[str] = []
     functions: list[str] = []
 
     # 1. Members declared in the module, in definition order. Pydantic registers parametrized
     # generics (e.g. ``View[Any]``) as module attributes whose ``__name__`` is not a valid
     # identifier; those are implementation details and must be skipped.
-    for obj in vars(module).values():
+    for name, obj in vars(module).items():
         if isinstance(obj, type) and obj.__module__ == module.__name__ and obj.__name__.isidentifier():
             blocks.append(_render_class(obj, imports))
             emitted.add(id(obj))
-        elif inspect.isfunction(obj) and obj.__module__ == module.__name__:
-            functions.append(_render_def(obj.__name__, obj, imports))
+            emitted_names.add(obj.__name__)
+        # Use the attribute name, not ``obj.__name__``: a module-level lambda is bound to a real
+        # name but reports ``__name__`` as ``"<lambda>"``.
+        elif inspect.isfunction(obj) and obj.__module__ == module.__name__ and name.isidentifier():
+            functions.append(_render_def(name, obj, imports))
+            emitted_names.add(name)
 
     # 2. Views generated at runtime that are not module attributes, sorted for stable output.
     runtime_views = [v for v in _collect_runtime_views(module) if id(v) not in emitted]
     for view_cls in sorted(runtime_views, key=lambda v: v.__name__):
         blocks.append(_render_model(view_cls, imports))
         emitted.add(id(view_cls))
+        emitted_names.add(view_cls.__name__)
+
+    # 3. Module-level variables and constants defined in the module.
+    variables = _render_module_variables(module, imports, emitted_names)
 
     header = (
         "# Stub generated by pydantic_views.stubgen. Includes regular types, Pydantic models,\n"
         "# declared views, and views generated at runtime by the builders.\n"
     )
     import_block = imports.render_block()
+    variable_block = "\n".join(variables)
     body = "\n\n\n".join([*blocks, *functions])
-    sections = [header, import_block, body]
+    sections = [header, import_block, variable_block, body]
     return "\n\n".join(section for section in sections if section).rstrip() + "\n"
 
 
@@ -466,7 +546,12 @@ def main(argv: list[str] | None = None) -> int:
         prog="python -m pydantic_views.stubgen",
         description="Generate .pyi stubs (including runtime-generated views) for a module and its children.",
     )
-    parser.add_argument("module", help="Importable module name, e.g. examples.models")
+    parser.add_argument(
+        "modules",
+        nargs="+",
+        metavar="module",
+        help="One or more importable module names, e.g. examples.models examples.other",
+    )
     parser.add_argument(
         "-o",
         "--output-dir",
@@ -479,9 +564,9 @@ def main(argv: list[str] | None = None) -> int:
     if "" not in sys.path and "." not in sys.path:
         sys.path.insert(0, "")
 
-    written = generate(args.module, args.output_dir)
-    for path in written:
-        print(f"wrote {path}")
+    for module_name in args.modules:
+        for path in generate(module_name, args.output_dir):
+            print(f"wrote {path}")
     return 0
 
 

--- a/src/pydantic_views/stubgen.py
+++ b/src/pydantic_views/stubgen.py
@@ -1,0 +1,489 @@
+"""
+Generate ``.pyi`` stub files for a Python module (and its submodules) at runtime.
+
+Unlike ``mypy.stubgen``, this generator imports the target module and introspects it directly.
+That matters for :mod:`pydantic_views`: a static stub generator only sees the *declared* views as
+empty ``BaseModel`` subclasses, because their fields are synthesised. By importing the module we can
+read the real :pyattr:`~pydantic.BaseModel.model_fields` of every view, including the views generated
+at runtime by the builders (for example the nested ``AddressLoad`` view created while building
+``UserLoad``).
+
+The emitted stub for each module contains:
+
+* every regular class defined in the module (plain classes, enums, and Pydantic models);
+* every view declared in the module source;
+* every view generated at runtime for a model defined in the module;
+* module-level functions.
+
+Usage::
+
+    python -m pydantic_views.stubgen examples.models
+    python -m pydantic_views.stubgen examples.models --output-dir build/stubs
+
+By default each ``.pyi`` is written next to its source ``.py``. With ``--output-dir`` the package
+tree is mirrored under the given directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections.abc
+import enum
+import importlib
+import inspect
+import pkgutil
+import sys
+import types
+import typing
+from pathlib import Path
+from typing import Any, get_args, get_origin
+
+from pydantic import BaseModel
+
+from .view import RootView, View
+
+_EMPTY = inspect.Parameter.empty
+_SIMPLE_LITERALS = (bool, int, str, bytes, type(None))
+
+# Some classes are exposed from a public module that differs from their defining (private) module.
+# Importing from the private location is valid, but the canonical public import reads better.
+_CANONICAL_MODULES = {
+    ("pydantic.main", "BaseModel"): "pydantic",
+    ("pydantic.root_model", "RootModel"): "pydantic",
+}
+
+# A few classes report ``builtins`` as their module but a name that is not a builtin global
+# (e.g. ``types.ModuleType.__qualname__`` is ``"module"``). Map them to their importable location.
+_CANONICAL_TYPES = {
+    types.ModuleType: ("types", "ModuleType"),
+    types.FunctionType: ("types", "FunctionType"),
+    types.MethodType: ("types", "MethodType"),
+}
+
+
+class Imports:
+    """Accumulates the imports required to render a single module stub.
+
+    References to names defined in the module being generated, and to builtins, are rendered bare;
+    everything else is recorded as a ``from <module> import <name>`` statement.
+    """
+
+    def __init__(self, current_module: str) -> None:
+        self._current_module = current_module
+        self._from: dict[str, set[str]] = {}
+
+    @property
+    def current_module(self) -> str:
+        """Name of the module whose stub is being generated."""
+        return self._current_module
+
+    def add(self, module: str, name: str) -> None:
+        """Record ``from module import name`` unless it is local or a builtin."""
+        if module in ("builtins", self._current_module) or not module:
+            return
+        self._from.setdefault(module, set()).add(name)
+
+    def add_typing(self, name: str) -> None:
+        """Record a name imported from :mod:`typing` (``Any``, ``Literal``, ...)."""
+        self._from.setdefault("typing", set()).add(name)
+
+    def ref(self, tp: type) -> str:
+        """Return the rendered reference to a class, recording its import if needed.
+
+        A parametrized generic subclass built by Pydantic carries a ``[...]`` suffix in its
+        ``__qualname__`` (e.g. ``View[TypeVar]``); only the bare leading name is importable.
+        """
+        if tp in _CANONICAL_TYPES:
+            module, name = _CANONICAL_TYPES[tp]
+            self.add(module, name)
+            return name
+        name = tp.__qualname__.split("[", 1)[0]
+        module = _CANONICAL_MODULES.get((tp.__module__, name), tp.__module__)
+        self.add(module, name.split(".")[0])
+        return name
+
+    def render_block(self) -> str:
+        """Return the import block, sorted for stable output."""
+        lines: list[str] = []
+        for module in sorted(self._from):
+            names = ", ".join(sorted(self._from[module]))
+            lines.append(f"from {module} import {names}")
+        return "\n".join(lines)
+
+
+def render_annotation(tp: Any, imports: Imports) -> str:
+    """Render a runtime annotation object as stub-ready source text."""
+    if tp is None or tp is type(None):
+        return "None"
+    if tp is Ellipsis:
+        return "..."
+    if tp is Any:
+        imports.add_typing("Any")
+        return "Any"
+    if isinstance(tp, str):
+        return tp
+    if isinstance(tp, typing.ForwardRef):
+        return tp.__forward_arg__
+    if isinstance(tp, typing.TypeVar):
+        return tp.__name__
+
+    # ``Annotated[T, ...]``: keep ``T``, drop the metadata (access modes, validators, ...).
+    if hasattr(tp, "__metadata__"):
+        return render_annotation(tp.__origin__, imports)
+
+    origin = get_origin(tp)
+    if origin is not None:
+        args = get_args(tp)
+        if origin is typing.Union or origin is types.UnionType:
+            return " | ".join(render_annotation(a, imports) for a in args)
+        if origin is typing.Literal:
+            imports.add_typing("Literal")
+            return "Literal[" + ", ".join(repr(a) for a in args) + "]"
+        if origin is collections.abc.Callable:
+            imports.add("collections.abc", "Callable")
+            params, ret = args[0], args[-1]
+            if params is Ellipsis:
+                rendered_params = "..."
+            else:
+                rendered_params = "[" + ", ".join(render_annotation(p, imports) for p in params) + "]"
+            return f"Callable[{rendered_params}, {render_annotation(ret, imports)}]"
+        base = imports.ref(origin) if isinstance(origin, type) else _render_special_form(origin, imports)
+        if args:
+            return f"{base}[{', '.join(render_annotation(a, imports) for a in args)}]"
+        return base
+
+    if isinstance(tp, type):
+        return imports.ref(tp)
+
+    return "Any"
+
+
+def _render_special_form(origin: Any, imports: Imports) -> str:
+    """Render a :mod:`typing` special form (``ClassVar``, ``Final``, ...) and record its import."""
+    name = getattr(origin, "_name", None) or getattr(origin, "__name__", None)
+    if getattr(origin, "__module__", None) == "typing" and name:
+        imports.add_typing(name)
+        return name
+    return str(origin)
+
+
+def _render_bases(cls: type, imports: Imports) -> str:
+    """Render a class's base list, dropping ``object``/``Generic`` and parametrization suffixes.
+
+    Pydantic builds concrete generic subclasses whose ``__qualname__`` contains a ``[...]`` suffix
+    (e.g. ``RootModel[TypeVar]``); the bare class name is what is actually importable.
+    """
+    rendered: list[str] = []
+    for base in cls.__bases__:
+        if base is object or base is typing.Generic:
+            continue
+        rendered.append(imports.ref(base))
+    return ", ".join(rendered) if rendered else "object"
+
+
+def _is_concrete_view(cls: Any) -> bool:
+    """True for a built view that exposes a resolvable source model (not the ``View`` base itself)."""
+    if not (isinstance(cls, type) and issubclass(cls, View)) or cls in (View, RootView):
+        return False
+    try:
+        cls.view_class_root()
+    except Exception:
+        return False
+    return True
+
+
+def _render_type_params(obj: Any, imports: Imports) -> str:
+    """Render PEP 695 type parameters (``[T, U: Bound]``) for a class or function, or ``""``."""
+    params = getattr(obj, "__type_params__", ())
+    if not params:
+        return ""
+    rendered: list[str] = []
+    for param in params:
+        if isinstance(param, typing.ParamSpec):
+            prefix = "**"
+        elif isinstance(param, typing.TypeVarTuple):
+            prefix = "*"
+        else:
+            prefix = ""
+        text = f"{prefix}{param.__name__}"
+        bound = getattr(param, "__bound__", None)
+        constraints = getattr(param, "__constraints__", ())
+        if bound is not None:
+            text += f": {render_annotation(bound, imports)}"
+        elif constraints:
+            text += f": ({', '.join(render_annotation(c, imports) for c in constraints)})"
+        rendered.append(text)
+    return "[" + ", ".join(rendered) + "]"
+
+
+def _render_def(name: str, func: Any, imports: Imports) -> str:
+    """Render a ``def`` line (with type parameters) for a function or method."""
+    return f"def {name}{_render_type_params(func, imports)}{_render_signature(func, imports)}: ..."
+
+
+def _render_signature(func: Any, imports: Imports) -> str:
+    """Best-effort render of a function/method signature for the stub."""
+    try:
+        # ``eval_str=True`` resolves the string annotations produced by ``from __future__ import
+        # annotations`` into real objects, so they can be rendered with their imports recorded.
+        sig = inspect.signature(func, eval_str=True)
+    except (TypeError, ValueError, NameError):
+        try:
+            sig = inspect.signature(func)
+        except (TypeError, ValueError):
+            imports.add_typing("Any")
+            return "(*args: Any, **kwargs: Any) -> Any"
+
+    parts: list[str] = []
+    for name, param in sig.parameters.items():
+        if param.kind is inspect.Parameter.VAR_POSITIONAL:
+            rendered = f"*{name}"
+        elif param.kind is inspect.Parameter.VAR_KEYWORD:
+            rendered = f"**{name}"
+        else:
+            rendered = name
+            if param.annotation is not _EMPTY:
+                rendered += f": {render_annotation(param.annotation, imports)}"
+            if param.default is not _EMPTY:
+                rendered += " = ..."
+        parts.append(rendered)
+
+    if sig.return_annotation is not _EMPTY:
+        ret = render_annotation(sig.return_annotation, imports)
+    else:
+        ret = "None" if func.__name__ in ("__init__", "__new__") else "Any"
+        if ret == "Any":
+            imports.add_typing("Any")
+    return f"({', '.join(parts)}) -> {ret}"
+
+
+def _render_init(model: type[BaseModel], imports: Imports) -> str:
+    """Render a keyword-only ``__init__`` from a model's fields."""
+    params: list[str] = []
+    for name, field in model.model_fields.items():
+        rendered = f"{name}: {render_annotation(field.annotation, imports)}"
+        if not field.is_required():
+            rendered += " = ..."
+        params.append(rendered)
+    signature = ", ".join(["self", "*", *params]) if params else "self"
+    return f"    def __init__({signature}) -> None: ..."
+
+
+def _render_model(cls: type[BaseModel], imports: Imports) -> str:
+    """Render a stub for a Pydantic model or view."""
+    if _is_concrete_view(cls):
+        view_base = "RootView" if issubclass(cls, RootView) else "View"
+        imports.add("pydantic_views", view_base)
+        base = f"{view_base}[{render_annotation(cls.view_class_root(), imports)}]"  # type: ignore
+    else:
+        base = _render_bases(cls, imports)
+
+    lines = [f"class {cls.__name__}{_render_type_params(cls, imports)}({base}):"]
+    for name, field in cls.model_fields.items():
+        lines.append(f"    {name}: {render_annotation(field.annotation, imports)}")
+
+    # Computed fields are not declared in ``model_fields``; expose them as read-only properties.
+    # (View builders fold computed fields into ``model_fields`` already, so this only fires for
+    # regular models.)
+    for name, computed in cls.model_computed_fields.items():
+        lines.append("    @property")
+        lines.append(f"    def {name}(self) -> {render_annotation(computed.return_type, imports)}: ...")
+
+    lines.append(_render_init(cls, imports))
+    return "\n".join(lines)
+
+
+def _render_enum(cls: type[enum.Enum], imports: Imports) -> str:
+    lines = [f"class {cls.__name__}{_render_type_params(cls, imports)}({_render_bases(cls, imports)}):"]
+    for member in cls:
+        value = repr(member.value) if isinstance(member.value, _SIMPLE_LITERALS) else "..."
+        lines.append(f"    {member.name} = {value}")
+    return "\n".join(lines)
+
+
+def _render_plain_class(cls: type, imports: Imports) -> str:
+    base = _render_bases(cls, imports)
+    name = f"{cls.__name__}{_render_type_params(cls, imports)}"
+    header = f"class {name}:" if base == "object" else f"class {name}({base}):"
+    lines = [header]
+
+    annotations = getattr(cls, "__annotations__", {})
+    for name, annotation in annotations.items():
+        lines.append(f"    {name}: {render_annotation(annotation, imports)}")
+
+    for name, member in vars(cls).items():
+        if name.startswith("__") and name not in ("__init__", "__call__"):
+            continue
+        if isinstance(member, (staticmethod, classmethod)):
+            decorator = "staticmethod" if isinstance(member, staticmethod) else "classmethod"
+            lines.append(f"    @{decorator}")
+            lines.append(f"    {_render_def(name, member.__func__, imports)}")
+        elif inspect.isfunction(member):
+            lines.append(f"    {_render_def(name, member, imports)}")
+        elif isinstance(member, property) and member.fget is not None:
+            lines.append("    @property")
+            lines.append(f"    {_render_def(name, member.fget, imports)}")
+
+    if len(lines) == 1:
+        lines.append("    ...")
+    return "\n".join(lines)
+
+
+def _nested_classes(cls: type, imports: Imports) -> list[type]:
+    """Return the classes defined inside ``cls`` (e.g. a nested enum), in definition order.
+
+    A class is considered genuinely nested only when its ``__qualname__`` is ``<cls>.<name>`` and it
+    belongs to the module being generated; this excludes classes merely assigned as attributes.
+    """
+    return [
+        member
+        for member in vars(cls).values()
+        if isinstance(member, type)
+        and member.__module__ == imports.current_module
+        and member.__qualname__ == f"{cls.__qualname__}.{member.__name__}"
+    ]
+
+
+def _inject_nested(cls: type, rendered: str, imports: Imports) -> str:
+    """Insert the (recursively rendered) nested-class definitions after ``cls``'s header line."""
+    nested = _nested_classes(cls, imports)
+    if not nested:
+        return rendered
+    indented = "\n\n".join(
+        "\n".join(f"    {line}" if line.strip() else "" for line in _render_class(child, imports).split("\n"))
+        for child in nested
+    )
+    header, _, body = rendered.partition("\n")
+    return f"{header}\n{indented}" + (f"\n{body}" if body else "")
+
+
+def _render_class(cls: type, imports: Imports) -> str:
+    if issubclass(cls, BaseModel):
+        rendered = _render_model(cls, imports)
+    elif issubclass(cls, enum.Enum):
+        rendered = _render_enum(cls, imports)
+    else:
+        rendered = _render_plain_class(cls, imports)
+    return _inject_nested(cls, rendered, imports)
+
+
+def _collect_runtime_views(module: types.ModuleType) -> list[type[View[Any]]]:
+    """Collect views generated at runtime for models defined in ``module``.
+
+    These views (e.g. the nested ``AddressLoad``) live in their source model's view manager but are
+    never assigned as module attributes, so they would be missed by a plain ``vars(module)`` scan.
+    """
+    views: dict[str, type[View[Any]]] = {}
+    for obj in vars(module).values():
+        if not (isinstance(obj, type) and issubclass(obj, BaseModel)):
+            continue
+        if obj.__module__ != module.__name__:
+            continue
+        manager = getattr(obj, "model_views", None)
+        if manager is None:
+            continue
+        for view_cls in manager._views.values():
+            # Skip Pydantic-internal parametrized generics such as ``View[Any]`` (their names are
+            # not valid identifiers); keep only concrete, named views for this module.
+            if (
+                _is_concrete_view(view_cls)
+                and view_cls.__module__ == module.__name__
+                and view_cls.__name__.isidentifier()
+                and "[" not in view_cls.__qualname__
+            ):
+                views[view_cls.__name__] = view_cls
+    return list(views.values())
+
+
+def render_module(module: types.ModuleType) -> str:
+    """Render the full ``.pyi`` text for a single module."""
+    imports = Imports(module.__name__)
+    emitted: set[int] = set()
+    blocks: list[str] = []
+    functions: list[str] = []
+
+    # 1. Members declared in the module, in definition order. Pydantic registers parametrized
+    # generics (e.g. ``View[Any]``) as module attributes whose ``__name__`` is not a valid
+    # identifier; those are implementation details and must be skipped.
+    for obj in vars(module).values():
+        if isinstance(obj, type) and obj.__module__ == module.__name__ and obj.__name__.isidentifier():
+            blocks.append(_render_class(obj, imports))
+            emitted.add(id(obj))
+        elif inspect.isfunction(obj) and obj.__module__ == module.__name__:
+            functions.append(_render_def(obj.__name__, obj, imports))
+
+    # 2. Views generated at runtime that are not module attributes, sorted for stable output.
+    runtime_views = [v for v in _collect_runtime_views(module) if id(v) not in emitted]
+    for view_cls in sorted(runtime_views, key=lambda v: v.__name__):
+        blocks.append(_render_model(view_cls, imports))
+        emitted.add(id(view_cls))
+
+    header = (
+        "# Stub generated by pydantic_views.stubgen. Includes regular types, Pydantic models,\n"
+        "# declared views, and views generated at runtime by the builders.\n"
+    )
+    import_block = imports.render_block()
+    body = "\n\n\n".join([*blocks, *functions])
+    sections = [header, import_block, body]
+    return "\n\n".join(section for section in sections if section).rstrip() + "\n"
+
+
+def iter_module_tree(module: types.ModuleType) -> list[types.ModuleType]:
+    """Return ``module`` and, if it is a package, all of its importable submodules."""
+    modules = [module]
+    if hasattr(module, "__path__"):
+        for info in pkgutil.walk_packages(module.__path__, prefix=f"{module.__name__}."):
+            modules.append(importlib.import_module(info.name))
+    return modules
+
+
+def _output_path(module: types.ModuleType, output_dir: Path | None) -> Path:
+    source = Path(module.__file__)  # type: ignore[arg-type]
+    if output_dir is None:
+        return source.with_suffix(".pyi")
+    relative = Path(*module.__name__.split("."))
+    if source.name == "__init__.py":
+        relative = relative / "__init__"
+    return (output_dir / relative).with_suffix(".pyi")
+
+
+def generate(module_name: str, output_dir: Path | None = None) -> list[Path]:
+    """Generate stubs for ``module_name`` and its children, returning the written paths."""
+    root = importlib.import_module(module_name)
+    written: list[Path] = []
+    for module in iter_module_tree(root):
+        if getattr(module, "__file__", None) is None:
+            continue
+        path = _output_path(module, output_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(render_module(module))
+        written.append(path)
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m pydantic_views.stubgen",
+        description="Generate .pyi stubs (including runtime-generated views) for a module and its children.",
+    )
+    parser.add_argument("module", help="Importable module name, e.g. examples.models")
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory to mirror the package tree into. Defaults to writing each .pyi next to its source.",
+    )
+    args = parser.parse_args(argv)
+
+    if "" not in sys.path and "." not in sys.path:
+        sys.path.insert(0, "")
+
+    written = generate(args.module, args.output_dir)
+    for path in written:
+        print(f"wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_stubgen.py
+++ b/tests/test_stubgen.py
@@ -22,14 +22,17 @@ from pydantic_views.stubgen import (
     _collect_runtime_views,
     _inject_nested,
     _is_concrete_view,
+    _module_assigned_names,
     _output_path,
     _render_bases,
     _render_enum,
     _render_init,
+    _render_module_variables,
     _render_plain_class,
     _render_signature,
     _render_special_form,
     _render_type_params,
+    _target_names,
     generate,
     iter_module_tree,
     main,
@@ -131,6 +134,13 @@ def with_default(a, b=1): ...
 def future_unresolved(
     x: _UndefinedRuntimeName,  # noqa: F821 # type: ignore
 ) -> None: ...  # noqa: F821  -- string annotation only
+
+
+# Module-level variables exercised by the variable renderer.
+MODULE_CONSTANT: int = 7  # annotated -> uses the annotation
+inferred_constant = Color.RED  # unannotated -> type inferred from the runtime value
+unpacked_a, unpacked_b = 1, 2  # tuple-unpacked assignment
+module_lambda = lambda x: x  # noqa: E731  -- emitted as a function, not a variable
 
 
 @pytest.fixture
@@ -440,6 +450,97 @@ def test_write_only_field_dropped_from_load_view(stub: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Module-level variables
+# ---------------------------------------------------------------------------
+def _module_var_annotations(stub: str) -> dict[str, str]:
+    tree = _parse(stub)
+    return {
+        node.target.id: ast.unparse(node.annotation)
+        for node in tree.body
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name)
+    }
+
+
+def test_target_names_handles_unpacking() -> None:
+    assign = typing.cast(ast.Assign, ast.parse("a, (b, *c) = x").body[0])
+    assert _target_names(assign.targets[0]) == ["a", "b", "c"]
+
+
+def test_target_names_ignores_non_name_targets() -> None:
+    assign = typing.cast(ast.Assign, ast.parse("obj.attr = 1").body[0])
+    assert _target_names(assign.targets[0]) == []
+
+
+def test_module_assigned_names_unreadable_source() -> None:
+    module = types.ModuleType("bad_source_mod")
+    module.__file__ = "/nonexistent/path/does_not_exist.py"
+    assert _module_assigned_names(module) == []
+
+
+def test_render_module_variables_handles_unresolvable_hints_and_missing_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import importlib
+    import sys
+
+    source = (
+        "from __future__ import annotations\n"
+        "X: int = 1\n"
+        "Y: UnresolvableName = 2  # forces get_type_hints to fail\n"
+        "TEMP = 1\n"
+        "del TEMP  # assigned in source but absent at runtime\n"
+    )
+    (tmp_path / "tmp_vars_mod.py").write_text(source)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    module = importlib.import_module("tmp_vars_mod")
+    try:
+        lines = _render_module_variables(module, Imports("tmp_vars_mod"), skip=set())
+    finally:
+        sys.modules.pop("tmp_vars_mod", None)
+
+    assert "X: int" in lines  # resolved from the raw string annotation
+    assert "Y: UnresolvableName" in lines
+    assert not any(line.startswith("TEMP") for line in lines)  # value gone -> skipped
+
+
+def test_module_assigned_names_excludes_imports_and_definitions() -> None:
+    import tests.test_stubgen as module
+
+    names = _module_assigned_names(module)
+    assert {"MODULE_CONSTANT", "inferred_constant", "unpacked_a", "unpacked_b"} <= set(names)
+    # imported names and class/function definitions are not assignments
+    assert "BaseModel" not in names
+    assert "Author" not in names
+    assert "returns_int" not in names
+
+
+def test_module_assigned_names_without_source() -> None:
+    assert _module_assigned_names(types.ModuleType("no_source_mod")) == []
+
+
+def test_stub_renders_module_variables(stub: str) -> None:
+    annotations = _module_var_annotations(stub)
+    assert annotations["MODULE_CONSTANT"] == "int"  # from the declared annotation
+    assert annotations["inferred_constant"] == "Color"  # inferred from the runtime value
+    assert annotations["unpacked_a"] == "int"
+    assert annotations["unpacked_b"] == "int"
+
+
+def test_module_variables_skip_emitted_names(imports: Imports) -> None:
+    import tests.test_stubgen as module
+
+    # ``module_lambda`` is emitted as a function, so it must not also appear as a variable.
+    rendered = _render_module_variables(module, imports, skip={"module_lambda"})
+    assert not any(line.startswith("module_lambda:") for line in rendered)
+
+
+def test_stub_does_not_duplicate_lambda(stub: str) -> None:
+    # rendered once as a function definition, never as a module variable
+    assert "def module_lambda" in stub
+    assert "module_lambda:" not in stub
+
+
+# ---------------------------------------------------------------------------
 # iter_module_tree / _output_path
 # ---------------------------------------------------------------------------
 def test_iter_module_tree_single_module() -> None:
@@ -512,6 +613,14 @@ def test_main_when_cwd_already_on_path(
     monkeypatch.syspath_prepend("")  # exercise the branch where the cwd entry is already present
     assert main(["examples.models", "--output-dir", str(tmp_path)]) == 0
     capsys.readouterr()
+
+
+def test_main_accepts_multiple_modules(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    code = main(["examples.models", "tests.test_stubgen", "--output-dir", str(tmp_path)])
+    assert code == 0
+    assert "wrote" in capsys.readouterr().out
+    assert (tmp_path / "examples" / "models.pyi").exists()
+    assert (tmp_path / "tests" / "test_stubgen.pyi").exists()
 
 
 def test_render_annotation_handles_common_constructs() -> None:

--- a/tests/test_stubgen.py
+++ b/tests/test_stubgen.py
@@ -1,0 +1,524 @@
+"""Tests for :mod:`pydantic_views.stubgen`."""
+
+from __future__ import annotations
+
+import ast
+import enum
+import types
+import typing
+from abc import ABC
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, ClassVar, Literal
+
+import pytest
+from pydantic import BaseModel, RootModel, computed_field
+
+from pydantic_views import AccessMode, Builder, ReadOnly, RootView, View, WriteOnly
+from pydantic_views import stubgen as stubgen_module
+from pydantic_views.builder import ensure_model_views
+from pydantic_views.stubgen import (
+    Imports,
+    _collect_runtime_views,
+    _inject_nested,
+    _is_concrete_view,
+    _output_path,
+    _render_bases,
+    _render_enum,
+    _render_init,
+    _render_plain_class,
+    _render_signature,
+    _render_special_form,
+    _render_type_params,
+    generate,
+    iter_module_tree,
+    main,
+    render_annotation,
+    render_module,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level fixtures exercised by ``render_module`` and the helpers.
+# ---------------------------------------------------------------------------
+class Author(BaseModel):
+    id: ReadOnly[int]
+    name: str
+    secret: WriteOnly[str]
+
+    @computed_field
+    def label(self) -> str:
+        return self.name
+
+
+class AuthorCreate(
+    View[Author],
+    view_name="Create",
+    access_modes=(AccessMode.READ_AND_WRITE, AccessMode.WRITE_ONLY),
+):
+    pass
+
+
+class AuthorLoad(
+    View[Author],
+    view_name="Load",
+    access_modes=(AccessMode.READ_AND_WRITE, AccessMode.READ_ONLY),
+    include_computed_fields=True,
+):
+    pass
+
+
+class Color(enum.Enum):
+    RED = "red"
+    PAIR = (1, 2)  # non-literal value -> rendered as ``...``
+
+
+class Outer(BaseModel):
+    class Inner(enum.Enum):
+        A = "a"
+
+    kind: Inner
+    value: int
+
+
+# A plain (non-Pydantic, non-enum) class with every member kind.
+class Plain:
+    attr: int
+
+    def method(self, a: int) -> str: ...
+
+    @staticmethod
+    def stat(a: int) -> None: ...
+
+    @classmethod
+    def cls_method(cls) -> None: ...
+
+    @property
+    def prop(self) -> int: ...
+
+    def __init__(self, a: int): ...  # no return annotation -> ``None``
+
+
+class Empty:
+    pass
+
+
+# PEP 695 generic functions covering each kind of type parameter.
+def plain_generic[T](x: T) -> T: ...
+
+
+def bound_generic[T: int](x): ...
+
+
+def constrained_generic[T: (int, str)](x): ...
+
+
+def paramspec_generic[**P](x): ...
+
+
+def typevartuple_generic[*Ts](x): ...
+
+
+def returns_int() -> int: ...
+
+
+def varargs(*args, **kwargs): ...
+
+
+def with_default(a, b=1): ...
+
+
+def future_unresolved(
+    x: _UndefinedRuntimeName,  # noqa: F821 # type: ignore
+) -> None: ...  # noqa: F821  -- string annotation only
+
+
+@pytest.fixture
+def imports() -> Imports:
+    return Imports("tests.test_stubgen")
+
+
+@pytest.fixture
+def stub() -> str:
+    import tests.test_stubgen as module
+
+    return render_module(module)
+
+
+def _parse(stub: str) -> ast.Module:
+    """Parsing succeeds only if the generated stub is syntactically valid Python."""
+    return ast.parse(stub)
+
+
+def _class_names(stub: str) -> set[str]:
+    return {node.name for node in ast.walk(_parse(stub)) if isinstance(node, ast.ClassDef)}
+
+
+# ---------------------------------------------------------------------------
+# render_annotation
+# ---------------------------------------------------------------------------
+def test_render_annotation_scalars(imports: Imports) -> None:
+    assert render_annotation(None, imports) == "None"
+    assert render_annotation(type(None), imports) == "None"
+    assert render_annotation(..., imports) == "..."
+    assert render_annotation(Any, imports) == "Any"
+    assert render_annotation(int, imports) == "int"
+
+
+def test_render_annotation_string_and_forwardref(imports: Imports) -> None:
+    assert render_annotation("SomeName", imports) == "SomeName"
+    assert render_annotation(typing.ForwardRef("Fwd"), imports) == "Fwd"
+
+
+def test_render_annotation_typevar(imports: Imports) -> None:
+    tv = typing.TypeVar("MyVar")
+    assert render_annotation(tv, imports) == "MyVar"
+
+
+def test_render_annotation_annotated_strips_metadata(imports: Imports) -> None:
+    assert render_annotation(typing.Annotated[int, "meta"], imports) == "int"
+
+
+def test_render_annotation_union_and_containers(imports: Imports) -> None:
+    assert render_annotation(str | None, imports) == "str | None"
+    assert render_annotation(int | str, imports) == "int | str"
+    assert render_annotation(list[int], imports) == "list[int]"
+    assert render_annotation(dict[str, int], imports) == "dict[str, int]"
+
+
+def test_render_annotation_literal(imports: Imports) -> None:
+    assert render_annotation(Literal["a", "b"], imports) == "Literal['a', 'b']"
+
+
+def test_render_annotation_callable(imports: Imports) -> None:
+    assert render_annotation(Callable[[int, str], bool], imports) == "Callable[[int, str], bool]"
+    assert render_annotation(Callable[..., int], imports) == "Callable[..., int]"
+
+
+def test_render_annotation_classvar_special_form(imports: Imports) -> None:
+    assert render_annotation(ClassVar[int], imports) == "ClassVar[int]"
+    assert "from typing import ClassVar" in imports.render_block()
+
+
+def test_render_annotation_generic_without_args(imports: Imports) -> None:
+    # ``typing.List`` has list as origin but no args -> renders the bare base name.
+    assert render_annotation(typing.List, imports) == "list"  # noqa: UP006
+
+
+def test_render_annotation_unknown_falls_back_to_any(imports: Imports) -> None:
+    assert render_annotation(42, imports) == "Any"
+
+
+# ---------------------------------------------------------------------------
+# Imports
+# ---------------------------------------------------------------------------
+def test_imports_current_module() -> None:
+    assert Imports("a.b").current_module == "a.b"
+
+
+def test_imports_canonical_module(imports: Imports) -> None:
+    assert imports.ref(BaseModel) == "BaseModel"
+    assert "from pydantic import BaseModel" in imports.render_block()
+
+
+def test_imports_canonical_type(imports: Imports) -> None:
+    assert imports.ref(types.ModuleType) == "ModuleType"
+    assert "from types import ModuleType" in imports.render_block()
+
+
+def test_imports_skips_local_and_builtins() -> None:
+    imp = Imports("builtins")
+    imp.add("builtins", "int")
+    imp.add("", "weird")
+    assert imp.render_block() == ""
+
+
+# ---------------------------------------------------------------------------
+# _render_special_form
+# ---------------------------------------------------------------------------
+def test_render_special_form_non_typing(imports: Imports) -> None:
+    assert _render_special_form(123, imports) == "123"
+
+
+# ---------------------------------------------------------------------------
+# _render_bases / _is_concrete_view
+# ---------------------------------------------------------------------------
+def test_render_bases_object_when_no_real_bases(imports: Imports) -> None:
+    assert _render_bases(Empty, imports) == "object"
+
+
+def test_is_concrete_view_false_for_base_and_non_view() -> None:
+    assert _is_concrete_view(View) is False
+    assert _is_concrete_view(RootView) is False
+    assert _is_concrete_view(int) is False
+    assert _is_concrete_view(AuthorCreate) is True
+
+
+def test_is_concrete_view_false_when_root_unresolvable() -> None:
+    # An abstract View subclass never gets ``__model_class_root__`` set, so ``view_class_root``
+    # raises and the helper must report it is not a concrete view.
+    class Broken(View, ABC):
+        pass
+
+    assert _is_concrete_view(Broken) is False
+
+
+# ---------------------------------------------------------------------------
+# _render_type_params
+# ---------------------------------------------------------------------------
+def test_render_type_params_none(imports: Imports) -> None:
+    assert _render_type_params(returns_int, imports) == ""
+
+
+def test_render_type_params_plain_bound_constrained(imports: Imports) -> None:
+    assert _render_type_params(plain_generic, imports) == "[T]"
+    assert _render_type_params(bound_generic, imports) == "[T: int]"
+    assert _render_type_params(constrained_generic, imports) == "[T: (int, str)]"
+
+
+def test_render_type_params_paramspec_and_typevartuple(imports: Imports) -> None:
+    assert _render_type_params(paramspec_generic, imports) == "[**P]"
+    assert _render_type_params(typevartuple_generic, imports) == "[*Ts]"
+
+
+# ---------------------------------------------------------------------------
+# _render_signature
+# ---------------------------------------------------------------------------
+def test_render_signature_varargs(imports: Imports) -> None:
+    assert _render_signature(varargs, imports) == "(*args, **kwargs) -> Any"
+
+
+def test_render_signature_default_and_unannotated(imports: Imports) -> None:
+    assert _render_signature(with_default, imports) == "(a, b = ...) -> Any"
+
+
+def test_render_signature_return_annotation(imports: Imports) -> None:
+    assert _render_signature(returns_int, imports) == "() -> int"
+
+
+def test_render_signature_eval_failure_falls_back_to_strings(imports: Imports) -> None:
+    # ``eval_str=True`` raises NameError (annotation references an undefined name); the fallback
+    # keeps the raw string annotation.
+    assert _render_signature(future_unresolved, imports) == "(x: _UndefinedRuntimeName) -> None"
+
+
+def test_render_signature_uncallable_uses_safe_fallback(imports: Imports) -> None:
+    assert _render_signature(42, imports) == "(*args: Any, **kwargs: Any) -> Any"
+
+
+# ---------------------------------------------------------------------------
+# _render_init / _render_model
+# ---------------------------------------------------------------------------
+def test_render_init_no_fields(imports: Imports) -> None:
+    class NoFields(BaseModel):
+        pass
+
+    assert _render_init(NoFields, imports) == "    def __init__(self) -> None: ..."
+
+
+def test_render_model_view_and_computed_property(stub: str) -> None:
+    tree = _parse(stub)
+    author = next(n for n in ast.walk(tree) if isinstance(n, ast.ClassDef) and n.name == "Author")
+    # the computed field is rendered as a read-only property
+    props = [n for n in author.body if isinstance(n, ast.FunctionDef) and n.name == "label"]
+    assert props and any(isinstance(d, ast.Name) and d.id == "property" for d in props[0].decorator_list)
+
+
+def test_render_model_rootview_base() -> None:
+    class IntRoot(RootModel[int]):
+        pass
+
+    view = Builder("Load", access_modes=(AccessMode.READ_AND_WRITE, AccessMode.READ_ONLY)).build_view(IntRoot)
+    imports = Imports(IntRoot.__module__)
+    from pydantic_views.stubgen import _render_model
+
+    rendered = _render_model(view, imports)
+    assert rendered.startswith("class IntRootLoad(RootView[")
+    assert _is_concrete_view(view)
+
+
+# ---------------------------------------------------------------------------
+# _render_enum
+# ---------------------------------------------------------------------------
+def test_render_enum_simple_and_complex_values(imports: Imports) -> None:
+    rendered = _render_enum(Color, imports)
+    assert "RED = 'red'" in rendered
+    assert "PAIR = ..." in rendered  # tuple value is not a simple literal
+
+
+# ---------------------------------------------------------------------------
+# _render_plain_class
+# ---------------------------------------------------------------------------
+def test_render_plain_class_all_members(imports: Imports) -> None:
+    rendered = _render_plain_class(Plain, imports)
+    assert "attr: int" in rendered
+    assert "def method(self, a: int) -> str: ..." in rendered
+    assert "@staticmethod" in rendered
+    assert "@classmethod" in rendered
+    assert "@property" in rendered
+    assert "def __init__(self, a: int) -> None: ..." in rendered  # missing return -> None
+
+
+def test_render_plain_class_empty(imports: Imports) -> None:
+    assert _render_plain_class(Empty, imports) == "class Empty:\n    ..."
+
+
+# ---------------------------------------------------------------------------
+# _inject_nested
+# ---------------------------------------------------------------------------
+def test_inject_nested_renders_inner_class(stub: str) -> None:
+    tree = _parse(stub)
+    outer = next(n for n in ast.walk(tree) if isinstance(n, ast.ClassDef) and n.name == "Outer")
+    assert any(isinstance(n, ast.ClassDef) and n.name == "Inner" for n in outer.body)
+
+
+def test_inject_nested_no_children_returns_unchanged(imports: Imports) -> None:
+    assert _inject_nested(Empty, "class Empty: ...", imports) == "class Empty: ..."
+
+
+def test_inject_nested_single_line_header(imports: Imports) -> None:
+    # ``rendered`` has no body line; the nested block is appended after the header only.
+    result = _inject_nested(Outer, "class Outer(BaseModel): ...", imports)
+    assert result.startswith("class Outer(BaseModel): ...")
+    assert "    class Inner(Enum):" in result
+
+
+# ---------------------------------------------------------------------------
+# _collect_runtime_views
+# ---------------------------------------------------------------------------
+def test_collect_runtime_views_includes_generated_view() -> None:
+    import tests.test_stubgen as module
+    from pydantic_views import BuilderUpdate
+
+    BuilderUpdate().build_view(Author)
+    names = {v.__name__ for v in _collect_runtime_views(module)}
+    assert "AuthorUpdate" in names
+
+
+def test_collect_runtime_views_ignores_model_without_views() -> None:
+    isolated = types.ModuleType("isolated_mod")
+
+    class Lonely(BaseModel):
+        x: int
+
+    Lonely.__module__ = "isolated_mod"
+    isolated.Lonely = Lonely
+    isolated.not_a_class = 5
+    assert _collect_runtime_views(isolated) == []
+
+
+def test_collect_runtime_views_skips_non_concrete_entries() -> None:
+    isolated = types.ModuleType("isolated_mod2")
+
+    class Holder(BaseModel):
+        x: int
+
+    Holder.__module__ = "isolated_mod2"
+    isolated.Holder = Holder
+    # A manager entry that is not a concrete view must be filtered out.
+    ensure_model_views(Holder)._views["bogus"] = int
+    assert _collect_runtime_views(isolated) == []
+
+
+# ---------------------------------------------------------------------------
+# render_module integration
+# ---------------------------------------------------------------------------
+def test_stub_is_valid_python(stub: str) -> None:
+    _parse(stub)
+
+
+def test_includes_regular_model_and_declared_views(stub: str) -> None:
+    assert {"Author", "AuthorCreate", "AuthorLoad"} <= _class_names(stub)
+
+
+def test_write_only_field_dropped_from_load_view(stub: str) -> None:
+    tree = _parse(stub)
+    load = next(n for n in ast.walk(tree) if isinstance(n, ast.ClassDef) and n.name == "AuthorLoad")
+    annotated = {n.target.id for n in load.body if isinstance(n, ast.AnnAssign) and isinstance(n.target, ast.Name)}
+    assert "secret" not in annotated
+    assert {"id", "name", "label"} <= annotated
+
+
+# ---------------------------------------------------------------------------
+# iter_module_tree / _output_path
+# ---------------------------------------------------------------------------
+def test_iter_module_tree_single_module() -> None:
+    import examples.models as mod
+
+    assert iter_module_tree(mod) == [mod]
+
+
+def test_iter_module_tree_walks_package() -> None:
+    import pydantic_views
+
+    modules = iter_module_tree(pydantic_views)
+    names = {m.__name__ for m in modules}
+    assert "pydantic_views" in names
+    assert "pydantic_views.builder" in names
+    assert len(modules) > 1
+
+
+def test_output_path_in_place() -> None:
+    import examples.models as mod
+
+    assert _output_path(mod, None) == Path(mod.__file__).with_suffix(".pyi")
+
+
+def test_output_path_mirrored(tmp_path: Path) -> None:
+    import examples.models as mod
+
+    assert _output_path(mod, tmp_path) == tmp_path / "examples" / "models.pyi"
+
+
+def test_output_path_package_init(tmp_path: Path) -> None:
+    import pydantic_views
+
+    assert _output_path(pydantic_views, tmp_path) == tmp_path / "pydantic_views" / "__init__.pyi"
+
+
+# ---------------------------------------------------------------------------
+# generate / main
+# ---------------------------------------------------------------------------
+def test_generate_writes_parsable_stub(tmp_path: Path) -> None:
+    written = generate("examples.models", tmp_path)
+    assert written == [tmp_path / "examples" / "models.pyi"]
+    _parse(written[0].read_text())
+
+
+def test_generate_whole_package_parses(tmp_path: Path) -> None:
+    written = generate("pydantic_views", tmp_path)
+    assert len(written) > 1
+    for path in written:
+        _parse(path.read_text())
+
+
+def test_generate_skips_module_without_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = types.ModuleType("fake_namespace_pkg")  # a namespace-style module has no ``__file__``
+    monkeypatch.setattr(stubgen_module.importlib, "import_module", lambda name: fake)
+    monkeypatch.setattr(stubgen_module, "iter_module_tree", lambda module: [fake])
+    assert generate("fake_namespace_pkg") == []
+
+
+def test_main_returns_zero_and_reports(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    code = main(["examples.models", "--output-dir", str(tmp_path)])
+    assert code == 0
+    assert "wrote" in capsys.readouterr().out
+    assert (tmp_path / "examples" / "models.pyi").exists()
+
+
+def test_main_when_cwd_already_on_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.syspath_prepend("")  # exercise the branch where the cwd entry is already present
+    assert main(["examples.models", "--output-dir", str(tmp_path)]) == 0
+    capsys.readouterr()
+
+
+def test_render_annotation_handles_common_constructs() -> None:
+    imports = Imports("somewhere")
+    assert render_annotation(int, imports) == "int"
+    assert render_annotation(str | None, imports) == "str | None"
+    assert render_annotation(list[int], imports) == "list[int]"
+    assert render_annotation(dict[str, int], imports) == "dict[str, int]"
+    assert render_annotation(Literal["a", "b"], imports) == "Literal['a', 'b']"
+    assert render_annotation(None, imports) == "None"


### PR DESCRIPTION
This pull request updates the documentation and example models to highlight and demonstrate the new static type checking support via a bundled mypy plugin and a new `.pyi` stub generator. The documentation now explains how to use the stub generator for type checkers that do not support mypy plugins, and the example models are enhanced to showcase full support for enums, nested enums, and functions using generated views.

**Documentation improvements for static type checking:**

* Added mention of the bundled mypy plugin and `.pyi` stub generator for static type checking in the `README.rst` Features list.
* Expanded documentation in `README.rst` and `docs/source/type_checking.rst` to explain the new stub generator, including usage instructions, command-line examples, and a detailed description of what the generated stubs contain. [[1]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL513-R525) [[2]](diffhunk://#diff-4d0d8596b0971b7aff4e83b066d32e01aad16998d9674df0e504ea8bb43ee7c1L95-R133) [[3]](diffhunk://#diff-4d0d8596b0971b7aff4e83b066d32e01aad16998d9674df0e504ea8bb43ee7c1L209-R171)
* Clarified that the stub generator works at runtime and is not subject to the static analysis limitations of the mypy plugin.

**Enhancements to example models:**

* Added new enums (`AddressType`, `RoleType`) and demonstrated their use in `Address` and `Role` models to show that enums and nested enums are preserved by the mypy plugin and stub generator. [[1]](diffhunk://#diff-17f5523c5ba50e0881d8ce3e619e0e3ebb0d1b87bdb268106f102d000f2cbc76R21) [[2]](diffhunk://#diff-17f5523c5ba50e0881d8ce3e619e0e3ebb0d1b87bdb268106f102d000f2cbc76R39-R71)
* Added a sample function `get_user_display_name` that uses a generated view, illustrating that generated views are fully usable in type-checked code.